### PR TITLE
Fix 'Too much SYNC Parsing' issue

### DIFF
--- a/LpcAnalyzer.cpp
+++ b/LpcAnalyzer.cpp
@@ -604,9 +604,7 @@ bool LpcAnalyzer::ProcessSync() {
   // them?) a final value is driven (Ready, ReadyMore, Error) and the slave
   // stops driving. The master drives the bus afterwards for 1 clock.
   // Technically ReadyMore is only valid for DMA.
-  bool ready = false;
   while (true) {
-    bool is_last = ready;
     auto sync = LADRead1();
     if (!sync.has_value()) {
       // aborted during SYNC
@@ -614,9 +612,6 @@ bool LpcAnalyzer::ProcessSync() {
     }
     AddFrame(kSYNC, lck->GetSampleNumber(), 0, sync.value());
     if (sync == kReady || sync == kReadyMore || sync == kError) {
-      ready = true;
-    }
-    if (is_last) {
       break;
     }
   }


### PR DESCRIPTION
Hey there,

I recently used your LPC parser and noticed a bug, which caused wrong DATA outputs. In my case, these were specifically "IO Read" operations, where I noticed that every DATA byte started with 0xf. 

I was able to track it down to an issue with SYNC processing. The while loop was executed for at least two clock cycles, although there was only one SYNC cycle (namely READY in my case). Through this, the first nibble of DATA was interpreted as a SYNC value and the missing DATA was a actually taken from the first TAR cycle (which is always 0xf, obviously). 

Fixing the while loop by instantly breaking after a READY value is read did the job for me.

If you have any questions, hit me up :)

Best
Nils